### PR TITLE
Make Guess method accept string parameter

### DIFF
--- a/WOFClassLib.Tests/PuzzleTests.cs
+++ b/WOFClassLib.Tests/PuzzleTests.cs
@@ -30,7 +30,7 @@ namespace WOFClassLib.Tests
         [InlineData("dog", new char[] { 'g', 'g' }, "--G")]
         [InlineData("Dogs and Cats", new char[] { 'C', 'a', 'S', 'd' }, "D--S A-D CA-S")]
         [InlineData("LEAP", new char[] { 'x', 'p' }, "---P")]
-        public void TestGuessUpdatesPuzzle(string phrase, char[] guesses, string expectedResultDisplay)
+        public void TestGuessCharUpdatesPuzzle(string phrase, char[] guesses, string expectedResultDisplay)
         {
             Puzzle testPuzzle = new Puzzle(phrase);
             foreach (char guess in guesses)
@@ -41,10 +41,38 @@ namespace WOFClassLib.Tests
         }
 
         [Theory]
+        [InlineData("dog", new string[] { "d" }, "D--")]
+        [InlineData("Dog", new string[] { "o" }, "-O-")]
+        [InlineData("DOG", new string[] { "g", "o" }, "-OG")]
+        [InlineData("dog", new string[] { "g", "g" }, "--G")]
+        [InlineData("Dogs and Cats", new string[] { "C", "a", "S", "d" }, "D--S A-D CA-S")]
+        [InlineData("LEAP", new string[] { "x", "p" }, "---P")]
+        public void TestGuessStringUpdatesPuzzle(string phrase, string[] guesses, string expectedResultDisplay)
+        {
+            Puzzle testPuzzle = new Puzzle(phrase);
+            foreach (string guess in guesses)
+            {
+                testPuzzle.Guess(guess);
+            }
+            Assert.Equal(expectedResultDisplay, testPuzzle.GetPuzzleDisplay());
+        }
+
+        [Theory]
         [InlineData("QUEST", 'z', 0)]
         [InlineData("Wolf", 'w', 1)]
         [InlineData("Little Red Riding Hood", 'r', 2)]
-        public void TestGuessReturnsCorrectNumberOfMatches(string phrase, char guess, int expectedNumMatches)
+        public void TestGuessCharReturnsCorrectNumberOfMatches(string phrase, char guess, int expectedNumMatches)
+        {
+            Puzzle testPuzzle = new Puzzle(phrase);
+            int numberOfMatches = testPuzzle.Guess(guess);
+            Assert.Equal(expectedNumMatches, numberOfMatches);
+        }
+
+        [Theory]
+        [InlineData("QUEST", "z", 0)]
+        [InlineData("Wolf", "w", 1)]
+        [InlineData("Little Red Riding Hood", "r", 2)]
+        public void TestGuessStringReturnsCorrectNumberOfMatches(string phrase, string guess, int expectedNumMatches)
         {
             Puzzle testPuzzle = new Puzzle(phrase);
             int numberOfMatches = testPuzzle.Guess(guess);

--- a/WOFClassLib/Puzzle.cs
+++ b/WOFClassLib/Puzzle.cs
@@ -77,12 +77,48 @@ namespace WOFClassLib
             guess = char.ToUpper(guess);
             int numberOfMatches = 0;
             char[] currentDisplayArray = GetPuzzleDisplayAsArray();
-            for(int i = 0; i < phraseLength; i++)
+
+            for (int i = 0; i < phraseLength; i++)
             {
-                if(puzzlePhrase[i].Equals(guess))
+                if (puzzlePhrase[i].Equals(guess))
                 {
                     numberOfMatches++;
+
                     currentDisplayArray[i] = guess;
+
+                    if (!display.Contains('-'))
+                    {
+                        solved = true;
+                    }
+                }
+            }
+            return numberOfMatches;
+        }
+
+        public int Guess(string guess)
+        {
+            if(guess.Length != 1)
+            {
+                throw new ArgumentException("The guessed string must have a length of one.");
+            }
+
+            foreach(char c in guess)
+            {
+                if (!char.IsLetter(c))
+                {
+                    throw new ArgumentException("The guessed stringr must be a valid letter");
+                }
+            }
+
+            char guessed_char = char.ToUpper(guess[0]);
+            int numberOfMatches = 0;
+            char[] currentDisplayArray = GetPuzzleDisplayAsArray();
+            for(int i = 0; i < phraseLength; i++)
+            {
+                if(puzzlePhrase[i].Equals(guessed_char))
+                {
+                    numberOfMatches++;
+                    currentDisplayArray[i] = guessed_char;
                     if(!display.Contains('-'))
                     {
                         solved = true;


### PR DESCRIPTION
![ayyyye](https://media.giphy.com/media/3o7aCSpaRdjwK6fKj6/giphy.gif)
## Description 

This PR overloads the Guess method with a version that can accept a string as a parameter. This is so that the Game team can use it without having to cast user input to a char. Since the method is still overloaded with a version that accepts a char parameter, our legacy code will still build successfully. 