### PR TITLE
Add code coverage to testing and limit artifact staging

### DIFF
--- a/WOFClassLib.Tests/WOFClassLib.Tests.csproj
+++ b/WOFClassLib.Tests/WOFClassLib.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\coverlet.msbuild.2.6.3\build\coverlet.msbuild.props" Condition="Exists('..\packages\coverlet.msbuild.2.6.3\build\coverlet.msbuild.props')" />
   <Import Project="..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props')" />
   <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
@@ -83,6 +84,9 @@
     <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
     <Error Condition="!Exists('..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props'))" />
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\coverlet.msbuild.2.6.3\build\coverlet.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\coverlet.msbuild.2.6.3\build\coverlet.msbuild.props'))" />
+    <Error Condition="!Exists('..\packages\coverlet.msbuild.2.6.3\build\coverlet.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\coverlet.msbuild.2.6.3\build\coverlet.msbuild.targets'))" />
   </Target>
   <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
+  <Import Project="..\packages\coverlet.msbuild.2.6.3\build\coverlet.msbuild.targets" Condition="Exists('..\packages\coverlet.msbuild.2.6.3\build\coverlet.msbuild.targets')" />
 </Project>

--- a/WOFClassLib.Tests/packages.config
+++ b/WOFClassLib.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="coverlet.msbuild" version="2.6.3" targetFramework="net472" developmentDependency="true" />
   <package id="xunit" version="2.4.1" targetFramework="net472" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net472" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net472" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,16 +27,40 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
-- task: VSTest@2
+- task: DotNetCoreCLI@2
+  displayName: 'Install ReportGenerator'
   inputs:
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
+    command: custom
+    custom: tool
+    arguments: 'install --global dotnet-reportgenerator-globaltool'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Run unit tests - $(buildConfiguration)'
+  inputs:
+    command: 'test'
+    arguments: '--no-build --configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/Coverage/'
+    publishTestResults: true
+    projects: '**/*.Tests.csproj'
+
+- script: |
+    reportgenerator -reports:$(Build.SourcesDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/CodeCoverage -reporttypes:HtmlInline_AzurePipelines
+  displayName: 'Create code coverage report'
+
+- task: PublishCodeCoverageResults@1
+  displayName: 'Publish code coverage report'
+  inputs:
+    codeCoverageTool: 'cobertura'
+    summaryFileLocation: '$(Build.SourcesDirectory)/**/coverage.cobertura.xml'
 
 - task: CopyFiles@2
+  displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
   inputs:
-    Contents: '**\bin\**'
+    Contents: |
+     **\WheelOfFortune\bin\**\*.exe
+     **\WheelOfFortune\bin\**\*.dll
     TargetFolder: '$(Build.ArtifactStagingDirectory)'
-    
+
+
 - task: PublishBuildArtifacts@1
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
Add the testing code coverage and reports to the YAML pipeline. Also, limit the artifact binaries to include only the console app.

[AB#62](https://dev.azure.com/AzureDisaster/672e19f8-d8ff-494a-be6f-fc4ada15270e/_workitems/edit/62)