### PR TITLE
Displays phrase if puzzle is solved (Fixes AB #68)

### DIFF
--- a/WOFClassLib/Puzzle.cs
+++ b/WOFClassLib/Puzzle.cs
@@ -128,6 +128,7 @@ namespace WOFClassLib
             if(guess.ToUpper().Equals(puzzlePhrase))
             {
                 solved = true;
+                display = puzzlePhrase.ToCharArray();
                 return true;
             }
             else


### PR DESCRIPTION
## Description

This PR updates the display of a Puzzle with the full phrase solution, if the puzzle is solved. It fixes a bug where the incomplete puzzle is still shown at the end, after the player correctly solves it. 