### PR TITLE
When recycling list, exclude the last used phrase AB#74

### DIFF
--- a/WOFClassLib/Phrase.cs
+++ b/WOFClassLib/Phrase.cs
@@ -55,7 +55,14 @@ namespace WOFClassLib
             if (phrases.Count == 0)
             {
                 phrases = usedPhrases;
-                usedPhrases = new List<string>();
+
+                // Move the last phrase used to the usedPhrases, so we don't
+                // get the same phrase twice in a row
+
+                string lastPhase = phrases[phrases.Count - 1];
+                phrases.RemoveAt(phrases.Count - 1);
+                usedPhrases = new List<string> { lastPhase };
+
             }
 
             //grab a random phrase from the list


### PR DESCRIPTION
Phrase class unit test was failing intermittently because on occasion when recycling the list of phrases the same phrase would be called twice in a row.